### PR TITLE
allows kebab-case method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ $ aws-sdk-client-go ecs DescribeClusters '{"Cluster":"default"}'
 
 The third argument is JSON input for the method. If the method does not require input, you can omit the third argument (implicitly `{}` passed).
 
+If the method name is "kebab-case", it automatically converts to "PascalCase" (for example, `describe-clusters` -> `DescribeClusters`).
+
+```console
+$ aws-sdk-client-go ecs describe-clusters '{"Cluster":"default"}'
+```
+
+#### Query output by JMESPath
+
+`--query` option allows you to query the output by JMESPath like the AWS CLI.
+
+```console
+./aws-sdk-client-go ecs DescribeClusters '{"Cluster":"default"}' \
+  --query 'Clusters[0].ClusterArn'
+```
+
 #### Show help
 
 aws-sdk-client-go is a simple wrapper of the AWS SDK Go v2 service client. Its usage is the same as that of the AWS SDK Go v2.

--- a/main.go
+++ b/main.go
@@ -52,7 +52,8 @@ func (c *CLI) SetWriter(w io.Writer) {
 }
 
 func (c *CLI) CallMethod(ctx context.Context) error {
-	key := buildKey(c.Service, c.Method)
+	method := kebabToCamel(c.Method)
+	key := buildKey(c.Service, method)
 	if c.Input == "help" {
 		fmt.Fprintf(c.w, "See https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/%s\n", key)
 		return nil
@@ -135,6 +136,18 @@ func parseKey(key string) (string, string) {
 
 func buildKey(service, method string) string {
 	return fmt.Sprintf("%s#Client.%s", service, method)
+}
+
+func kebabToCamel(kebab string) string {
+	parts := strings.Split(kebab, "-")
+	results := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if len(p) == 0 {
+			continue
+		}
+		results = append(results, strings.ToUpper(p[:1])+p[1:])
+	}
+	return strings.Join(results, "")
 }
 
 //go:generate go run cmd/aws-sdk-client-gen/main.go cmd/aws-sdk-client-gen/gen.go


### PR DESCRIPTION
If the method name is "kebab-case", it automatically converts to "PascalCase" (for example, `describe-clusters` -> `DescribeClusters`).

```console
$ aws-sdk-client-go ecs describe-clusters '{"Cluster":"default"}'
```