### PR TITLE
add --dry-run (-n) flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Flags:
   -q, --query=STRING              JMESPath query to apply to output
       --ext-str=KEY=VALUE;...     external variables for Jsonnet
       --ext-code=KEY=VALUE;...    external code for Jsonnet
+  -n, --dry-run                   dry-run mode
   -v, --version                   show version
 ```
 
@@ -226,7 +227,7 @@ $ aws-sdk-client-go s3 get-object '{"Bucket": "my-bucket", "Key": "my.txt"}' --o
 
 When the output struct has only one field of `io.ReadCloser`, `aws-sdk-client-go` copies it to the file automatically. (Currently, all SDK output structs have at most one io.ReadCloser field.)
 
-If `--output-stream` is "-", `aws-sdk-client-go` writes into stdout. The result of the API also writes to stdout by default. If you don't want to output the result, use `--no-api-output` (`-n`).
+If `--output-stream` is "-", `aws-sdk-client-go` writes into stdout. The result of the API also writes to stdout by default. If you don't want to output the result, use `--no-api-output`.
 
 #### Query output by JMESPath
 

--- a/main.go
+++ b/main.go
@@ -35,7 +35,9 @@ type CLI struct {
 	Query        string            `short:"q" help:"JMESPath query to apply to output"`
 	ExtStr       map[string]string `help:"external variables for Jsonnet"`
 	ExtCode      map[string]string `help:"external code for Jsonnet"`
-	Version      bool              `short:"v" help:"show version"`
+
+	DryRun  bool `short:"n" help:"dry-run mode"`
+	Version bool `short:"v" help:"show version"`
 
 	w io.Writer
 }
@@ -82,6 +84,11 @@ func (c *CLI) CallMethod(ctx context.Context) error {
 		return err
 	}
 	defer p.Cleanup()
+
+	if c.DryRun {
+		fmt.Fprintf(c.w, "Dry-run: %s.%s() will be called with\n%s", c.Service, method, string(p.InputBytes))
+		return nil
+	}
 
 	out, err := fn(ctx, p)
 	if err != nil {


### PR DESCRIPTION
Shows service, method and input and exit.