### PR TITLE
add --follow-next option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Flags:
       --ext-str=KEY=VALUE;...     external variables for Jsonnet
       --ext-code=KEY=VALUE;...    external code for Jsonnet
       --[no-]strict               strict input JSON unmarshaling
+  -f, --follow-next=""            OutputField=InputField format. follow the next token.
   -n, --dry-run                   dry-run mode
   -v, --version                   show version
 ```
@@ -232,6 +233,32 @@ $ aws-sdk-client-go s3 get-object '{"Bucket": "my-bucket", "Key": "my.txt"}' --o
 When the output struct has only one field of `io.ReadCloser`, `aws-sdk-client-go` copies it to the file automatically. (Currently, all SDK output structs have at most one io.ReadCloser field.)
 
 If `--output-stream` is "-", `aws-sdk-client-go` writes into stdout. The result of the API also writes to stdout by default. If you don't want to output the result, use `--no-api-output`.
+
+#### `--raw-output` option
+
+`--raw-output` (`-r`) option allows you to output raw strings, not JSON texts.
+
+This option is like `jq -r`.
+
+#### `--follow-next` option
+
+`--follow-next` (`-f`) option set the output/input field name of the next token. This option is useful for paginated APIs.
+
+For example, [s3#ListObjectsV2Output](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#ListObjectsV2Output) has `NextContinuationToken` field, and [s3#ListObjectsV2Input](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#ListObjectsV2Input) has `ContinuationToken` field. You can follow the next token by the following command.
+
+`{FieldInOutput}={FieldInInput}` format is used for `--follow-next` option.
+
+```console
+$ aws-sdk-client-go s3 list-objects-v2 '{"Bucket": "my-bucket"}' \
+  --follow-next NextContinuationToken=ContinuationToken
+```
+
+If the same field name is used in the output and input, you can omit the input field name.
+
+```console
+$ aws-sdk-client-go ecs list-tasks '{"Cluster":"default"}' \
+  --follow-next NextToken
+```
 
 #### Query output by JMESPath
 

--- a/gen.yaml
+++ b/gen.yaml
@@ -2,6 +2,7 @@ services:
   ecs:
     - DescribeClusters
     - DescribeTasks
+    - ListTasks
   firehose:
     - DescribeDeliveryStream
     - ListDeliveryStreams

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.14
 	github.com/goccy/go-yaml v1.11.3
 	github.com/google/go-jsonnet v0.20.0
-	github.com/itchyny/gojq v0.12.15
 	github.com/jmespath/go-jmespath v0.4.0
 )
 
@@ -25,7 +24,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.8 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
 	github.com/fatih/color v1.12.0 // indirect
-	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	golang.org/x/sys v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,10 +48,6 @@ github.com/google/go-jsonnet v0.20.0 h1:WG4TTSARuV7bSm4PMB4ohjxe33IHT5WVTrJSU33u
 github.com/google/go-jsonnet v0.20.0/go.mod h1:VbgWF9JX7ztlv770x/TolZNGGFfiHEVx9G6ca2eUmeA=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/itchyny/gojq v0.12.15 h1:WC1Nxbx4Ifw5U2oQWACYz32JK8G9qxNtHzrvW4KEcqI=
-github.com/itchyny/gojq v0.12.15/go.mod h1:uWAHCbCIla1jiNxmeT5/B5mOjSdfkCq6p8vxWg+BM10=
-github.com/itchyny/timefmt-go v0.1.5 h1:G0INE2la8S6ru/ZI5JecgyzbbJNs5lG1RcBqa7Jm6GE=
-github.com/itchyny/timefmt-go v0.1.5/go.mod h1:nEP7L+2YmAbT2kZ2HfSs1d8Xtw9LY8D2stDBckWakZ8=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/param_test.go
+++ b/param_test.go
@@ -18,7 +18,7 @@ var ParamTestCases = []ParamTestCase{
 	{
 		Name: "inject nil",
 		Param: &sdkclient.ClientMethodParam{
-			InputBytes: []byte(`{"foo": "bar"}`),
+			InputBytes: []byte(`{"foo":"bar"}`),
 		},
 		Inject:       map[string]any{},
 		ExpectedJSON: `{"foo":"bar"}`,


### PR DESCRIPTION
#### `--follow-next` option

`--follow-next` (`-f`) option set the output/input field name of the next token. This option is useful for paginated APIs.

For example, [s3#ListObjectsV2Output](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#ListObjectsV2Output) has `NextContinuationToken` field, and [s3#ListObjectsV2Input](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#ListObjectsV2Input) has `ContinuationToken` field. You can follow the next token by the following command.

`{FieldInOutput}={FieldInInput}` format is used for `--follow-next` option.

```console
$ aws-sdk-client-go s3 list-objects-v2 '{"Bucket": "my-bucket"}' \
  --follow-next NextContinuationToken=ContinuationToken
```

If the same field name is used in the output and input, you can omit the input field name.

```console
$ aws-sdk-client-go ecs list-tasks '{"Cluster":"default"}' \
  --follow-next NextToken
```

